### PR TITLE
chore: re-enable tests in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -147,8 +147,8 @@ jobs:
       - name: List packages
         run: ls -R .
         shell: bash
-      # - name: Test bindings
-      #   run: yarn run test
+      - name: Test bindings
+        run: yarn run test
   test-linux-x64-gnu-binding:
     name: Test bindings on Linux-x64-gnu - node@${{ matrix.node }}
     needs:
@@ -177,8 +177,8 @@ jobs:
       - name: List packages
         run: ls -R .
         shell: bash
-      # - name: Test bindings
-      #   run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim corepack enable && yarn run test
+      - name: Test bindings
+        run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim corepack enable && yarn run test
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
@@ -209,12 +209,12 @@ jobs:
       - name: List packages
         run: ls -R .
         shell: bash
-      # - name: Test bindings
-      #   uses: addnab/docker-run-action@v3
-      #   with:
-      #     image: node:${{ matrix.node }}-alpine
-      #     options: '-v ${{ github.workspace }}:/build -w /build'
-      #     run: corepack enable && yarn install && yarn run test
+      - name: Test bindings
+        uses: addnab/docker-run-action@v3
+        with:
+          image: node:${{ matrix.node }}-alpine
+          options: '-v ${{ github.workspace }}:/build -w /build'
+          run: corepack enable && yarn install && yarn run test
   test-linux-aarch64-gnu-binding:
     name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
     needs:
@@ -246,12 +246,12 @@ jobs:
         with:
           platforms: arm64
       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      # - name: Setup and run tests
-      #   uses: addnab/docker-run-action@v3
-      #   with:
-      #     image: node:${{ matrix.node }}-slim
-      #     options: '--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build'
-      #     run: corepack enable && yarn run test
+      - name: Setup and run tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: node:${{ matrix.node }}-slim
+          options: '--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build'
+          run: corepack enable && yarn run test
   test-linux-aarch64-musl-binding:
     name: Test bindings on aarch64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
@@ -284,21 +284,15 @@ jobs:
         with:
           platforms: arm64
       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      # - name: Setup and run tests
-      #   uses: addnab/docker-run-action@v3
-      #   with:
-      #     image: node:${{ matrix.node }}-alpine
-      #     options: '--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build'
-      #     run: corepack enable && yarn install && yarn run test
+      - name: Setup and run tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: node:${{ matrix.node }}-alpine
+          options: '--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build'
+          run: corepack enable && yarn install && yarn run test
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    needs:
-      - test-macOS-windows-binding
-      - test-linux-x64-gnu-binding
-      - test-linux-x64-musl-binding
-      - test-linux-aarch64-gnu-binding
-      - test-linux-aarch64-musl-binding
     steps:
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
It was bad to completely disable tests in CI.
Rather, now, tests are run (so we can see what happens) but are not required for publish.