### PR TITLE
feat: add socket buffer size configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rustls = { version = "0.23.23", features = ["ring"] }
 tokio = { version = "1.43.0", features = ["full"] }
 # included to satisfy napi dependencies
 ctor = "0.3.6"
+socket2 = "0.5.8"
 
 [build-dependencies]
 napi-build = "2.1.4"

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -30,7 +30,8 @@ impl Server {
   pub fn new(config: &config::QuinnConfig, ip: String, port: u16) -> Result<Self> {
     let ip_addr = ip.parse::<IpAddr>().map_err(to_err)?;
     let socket_addr = SocketAddr::new(ip_addr, port);
-    let socket = std::net::UdpSocket::bind(socket_addr)?;
+    let socket = socket::create_socket(config.socket_config, socket_addr)?;
+
     let socket = block_on(async move{
       socket::UdpSocket::wrap_udp_socket(socket)
     })?;
@@ -93,7 +94,7 @@ impl Client {
       SocketFamily::Ipv6 => SocketAddr::new(std::net::Ipv6Addr::UNSPECIFIED.into(), 0),
     };
     let mut endpoint = block_on(async move {
-      let socket = std::net::UdpSocket::bind(bind_addr)?;
+      let socket = socket::create_socket(config.socket_config,bind_addr)?;
       let endpoint = quinn::Endpoint::new(
         config.endpoint_config.clone(),
         None,

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,5 +51,7 @@ export const defaultOptions: QuicOptions = {
   keepAliveInterval: 5_000,
   maxConcurrentStreamLimit: 256,
   maxStreamData: 10_000_000,
-  maxConnectionData: 15_000_000
+  maxConnectionData: 15_000_000,
+  receiveBufferSize: 500_000,
+  sendBufferSize: 500_000,
 }

--- a/src/napi.d.ts
+++ b/src/napi.d.ts
@@ -382,13 +382,38 @@ export interface Config {
    * concurrently by the remote peer.
    */
   maxConcurrentStreamLimit: number
-  /** Max unacknowledged data in bytes that may be sent on a single stream. */
+  /**
+   * Maximum number of bytes the peer may transmit without acknowledgement on any one stream
+   * before becoming blocked.
+   *
+   * This should be set to at least the expected connection latency multiplied by the maximum
+   * desired throughput. Setting this smaller than `max_connection_data` helps ensure that a single
+   * stream doesn't monopolize receive buffers, which may otherwise occur if the application
+   * chooses not to read from a large stream for a time while still requiring data on other
+   * streams.
+   */
   maxStreamData: number
   /**
-   * Max unacknowledged data in bytes that may be sent in total on all streams
-   * of a connection.
+   * Maximum number of bytes the peer may transmit across all streams of a connection before
+   * becoming blocked.
+   *
+   * This should be set to at least the expected connection latency multiplied by the maximum
+   * desired throughput. Larger values can be useful to allow maximum throughput within a
+   * stream while another is blocked.
    */
   maxConnectionData: number
+  /**
+   * OS socket receive buffer size.
+   *
+   * If this is set higher than the OS maximum, it will be clamped to the maximum allowed size.
+   */
+  receiveBufferSize: number
+  /**
+   * OS socket send buffer size.
+   *
+   * If this is set higher than the OS maximum, it will be clamped to the maximum allowed size.
+   */
+  sendBufferSize: number
 }
 
 export declare const enum SocketFamily {


### PR DESCRIPTION
Looking at performance [here](https://observablehq.com/@libp2p-workspace/performance-dashboard?branch=9dbf6d236d9f0fc615f8aa623f5b3ff2472a1c67) it appears quic has significantly reduced throughput compared with tcp. So what gives?
It may be that the OS buffer size is a factor. Whereas tcp typically has a growable OS-managed buffer, udp's buffers are fixed unless otherwise set by the application (or set via OS-wide configuration).

This PR exposes the send and receive buffer sizes (`SO_SNDBUF` and `SO_RCVBUF`) to be configurable.
Note that the OS imposes its own limits, so any values larger than the OS limits (typically for most OSs) will get clamped to the limit.

Various (semi)related links:
- https://github.com/mozilla/neqo/issues/1962
- https://yomo.run/docs/devops_tuning

TODO figure out good defaults