### PR TITLE
fix: remove aarch64 windows target

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "aarch64-unknown-linux-musl",
-      "aarch64-pc-windows-msvc",
       "x86_64-apple-darwin",
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-linux-gnu",


### PR DESCRIPTION
TODO fix ci and re-add if a user needs it