### PR TITLE
fix: do not throw unimplemented error

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -66,7 +66,7 @@ export class QuicListener extends TypedEventEmitter<ListenerEvents> implements L
   }
 
   updateAnnounceAddrs (addrs: Multiaddr[]): void {
-    throw new Error('Method not implemented.')
+
   }
 
   getAddrs (): Multiaddr[] {


### PR DESCRIPTION
We don't need to update announce addrs so don't throw a not implemented error.

Fixes #27