### PR TITLE
chore: fix manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ChainSafe/js-libp2p-quic"
+    "url": "git+https://github.com/ChainSafe/js-libp2p-quic.git"
   },
   "homepage": "https://github.com/ChainSafe/js-libp2p-quic",
   "scripts": {


### PR DESCRIPTION
There is a warning in the logs when publishing this package:

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/ChainSafe/js-libp2p-quic.git"
```

The change in this PR is made by `npm pkg fix` and should silence the warning in future.