### PR TITLE
chore: run IPv6 compliance tests in CI

### DIFF
--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -1,6 +1,7 @@
 import transportCompliance from '@libp2p/interface-compliance-tests/transport'
 import { QUICV1 } from '@multiformats/multiaddr-matcher'
 import { quic } from '../src/index.js'
+import { hostSupportsIpv6 } from './util.ts'
 
 describe('Interface compliance tests (IPv4)', () => {
   transportCompliance({
@@ -34,6 +35,11 @@ describe('Interface compliance tests (IPv4)', () => {
 })
 
 describe('Interface compliance tests (IPv6)', function () {
+  if (!hostSupportsIpv6()) {
+    it.skip('Host does not support IPv6', () => {})
+    return
+  }
+
   transportCompliance({
     async setup () {
       const dialer = {

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,10 +1,28 @@
 import { generateKeyPair } from '@libp2p/crypto/keys'
 import { defaultLogger } from '@libp2p/logger'
 import type { QuicComponents } from '../src/index.js'
+import { isIPv6 } from '@chainsafe/is-ip'
+import os from 'node:os'
 
 export async function createComponents (): Promise<QuicComponents> {
   return {
     privateKey: await generateKeyPair('Ed25519'),
     logger: defaultLogger()
   }
+}
+
+export function hostSupportsIpv6 (): boolean {
+  for (const interfaces of Object.values(os.networkInterfaces())) {
+    if (interfaces == null) {
+      continue
+    }
+
+    for (const info of interfaces) {
+      if (isIPv6(info.address)) {
+        return true
+      }
+    }
+  }
+
+  return false
 }


### PR DESCRIPTION
Other IPv6 tests in the suite run so we should be able to run the compliance tests.