### PR TITLE
fix: gracefully handle missing IPv4/IPv6 support in QUIC transport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,23 @@ import { QuicTransport } from './transport.js'
 import type * as napi from './napi.js'
 import type { ComponentLogger, DialTransportOptions, Metrics, PrivateKey, Transport } from '@libp2p/interface'
 
-export type QuicOptions = Omit<napi.Config, 'privateKeyProto'>
+export type QuicOptions = Omit<napi.Config, 'privateKeyProto'> & {
+  /**
+   * Enable IPv4 QUIC client for outbound connections.
+   * When set to false, IPv4 connections will not be supported.
+   *
+   * @default true
+   */
+  ipv4?: boolean
+
+  /**
+   * Enable IPv6 QUIC client for outbound connections.
+   * When set to false, IPv6 connections will not be supported.
+   *
+   * @default true
+   */
+  ipv6?: boolean
+}
 
 export interface QuicComponents {
   metrics?: Metrics

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -31,8 +31,8 @@ export class QuicTransport implements Transport {
   readonly #config: napi.QuinnConfig
 
   readonly #clients: {
-    ip4: napi.Client
-    ip6: napi.Client
+    ip4?: napi.Client
+    ip6?: napi.Client
   }
 
   readonly listenFilter: MultiaddrFilter
@@ -46,9 +46,32 @@ export class QuicTransport implements Transport {
     this.components = components
 
     this.#config = new napi.QuinnConfig(config)
+
+    let ip4Client: napi.Client | undefined
+    if (options.ipv4 !== false) {
+      try {
+        ip4Client = new napi.Client(this.#config, 0)
+      } catch {
+        this.log('IPv4 QUIC client not available')
+      }
+    }
+
+    let ip6Client: napi.Client | undefined
+    if (options.ipv6 !== false) {
+      try {
+        ip6Client = new napi.Client(this.#config, 1)
+      } catch {
+        this.log('IPv6 QUIC client not available')
+      }
+    }
+
+    if (ip4Client == null && ip6Client == null) {
+      throw new Error('At least one of ipv4 or ipv6 must be enabled for QUIC transport')
+    }
+
     this.#clients = {
-      ip4: new napi.Client(this.#config, 0),
-      ip6: new napi.Client(this.#config, 1)
+      ip4: ip4Client,
+      ip6: ip6Client
     }
 
     this.metrics = {
@@ -76,6 +99,10 @@ export class QuicTransport implements Transport {
     this.log('dialing', ma.toString())
     const addr = nodeAddressFromMultiaddr(ma)
     const dialer = addr.family === 4 ? this.#clients.ip4 : this.#clients.ip6
+
+    if (dialer == null) {
+      throw new Error(`No QUIC client available for IPv${addr.family}`)
+    }
 
     const dialPromise = dialer.outboundConnection(addr.address, addr.port)
     dialPromise


### PR DESCRIPTION
## Problem

The `QuicTransport` constructor unconditionally creates both IPv4 and IPv6 QUIC clients at construction time (`transport.ts:49-51`):

```ts
this.#clients = {
  ip4: new napi.Client(this.#config, 0),
  ip6: new napi.Client(this.#config, 1)  // crashes on IPv6-disabled systems
}
```

On systems where IPv6 is disabled at the kernel level, the `napi.Client(config, 1)` call fails immediately with:
```
Error: Address family not supported by protocol (os error 97)
```

This crashes the entire process during startup, preventing Lodestar (and any other libp2p consumer) from using QUIC on IPv4-only systems.

**Reported by:** eth-docker user running Lodestar with `--quic` on a system with IPv6 disabled.

## Changes

### 1. New `ipv4` and `ipv6` options
Added `ipv4?: boolean` and `ipv6?: boolean` to `QuicOptions` (both default to `true`). Consumers can explicitly disable either protocol when not needed.

### 2. Graceful fallback with try/catch
Both IPv4 and IPv6 client creation are wrapped in try/catch. If either fails at the OS level, a warning is logged and the transport falls back to whichever protocol(s) succeeded. At least one must succeed or the constructor throws.

### 3. Clear error on dial without client
If a consumer tries to dial an address for a protocol whose client is not available, a descriptive error is thrown (`No QUIC client available for IPv{4,6}`).

## Behavior

| Scenario | Before | After |
|---|---|---|
| Both available, defaults | Both clients created ✅ | Both clients created ✅ |
| IPv6 disabled at OS, defaults | Process crash ❌ | Warning logged, IPv4-only ✅ |
| IPv4 disabled at OS, defaults | Process crash ❌ | Warning logged, IPv6-only ✅ |
| `ipv6: false` | N/A | IPv4-only, no IPv6 attempt ✅ |
| `ipv4: false` | N/A | IPv6-only, no IPv4 attempt ✅ |
| Both disabled or both fail | N/A | Constructor throws ✅ |
| Dial IPv6 without IPv6 client | Crash | Clear error message ✅ |
| Dial IPv4 without IPv4 client | Crash | Clear error message ✅ |

---
*This PR was created with assistance from Lodekeeper 🌟*