### PR TITLE
fix: pin npm for releases

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -247,9 +247,9 @@ jobs:
         with:
           node-version: 22
       - name: Update npm
-        run: npm install -g npm
+        run: npm install -g npm@12.0.1
         shell: bash
-        if: ${{ steps.release.outputs.release_created }}                  
+        if: ${{ steps.release.outputs.release_created }}
       - name: Install dependencies
         if: ${{ steps.release.outputs.release_created }}
         run: pnpm install


### PR DESCRIPTION
## Summary

Pins the release workflow npm self-update to npm 12.0.1.

npm 12.0.0 omitted its bundled `sigstore` dependency, causing `npm publish --provenance` to fail after Release Please created the v2.1.0 release. Pinning avoids unreviewed npm releases and restores the existing automatic publish flow for the next patch release.

## Validation

- `pnpm lint`

> This PR was written with Codex assistance.