### PR TITLE
fix: bound QUIC listener shutdown

### DIFF
--- a/rust/config.rs
+++ b/rust/config.rs
@@ -66,21 +66,6 @@ pub struct Config {
   pub handshake_timeout: u32,
 
   /// Maximum duration in ms for draining the server endpoint during shutdown.
-  ///
-  /// The 3s default is derived from QUIC's draining period:
-  ///
-  /// quinn arms each connection's close/drain timer at 3x PTO (RFC 9000 §10.2)
-  ///
-  /// PTO = RTT + 4x RTT variance + the peer's max_ack_delay
-  ///
-  /// RTT = 333ms
-  /// RTT variance: RTT / 2
-  /// PTO = 333 ms + 4 × 166.5 ms = 999 ms
-  /// 3 * PTO = roughly 3s
-  ///
-  /// This timeout can only trip when a connection driver has stopped unexpectedly.
-  /// Waiting longer cannot help — an unbounded wait
-  /// hangs the caller's entire shutdown (see ChainSafe/lodestar#9744).
   pub shutdown_timeout: u32,
 
   /// Maximum duration of inactivity in ms to accept before timing out the connection.

--- a/rust/config.rs
+++ b/rust/config.rs
@@ -66,6 +66,21 @@ pub struct Config {
   pub handshake_timeout: u32,
 
   /// Maximum duration in ms for draining the server endpoint during shutdown.
+  ///
+  /// The 3s default is derived from QUIC's draining period:
+  ///
+  /// quinn arms each connection's close/drain timer at 3x PTO (RFC 9000 §10.2)
+  ///
+  /// PTO = RTT + 4x RTT variance + the peer's max_ack_delay
+  ///
+  /// RTT = 333ms
+  /// RTT variance: RTT / 2
+  /// PTO = 333 ms + 4 × 166.5 ms = 999 ms
+  /// 3 * PTO = roughly 3s
+  ///
+  /// This timeout can only trip when a connection driver has stopped unexpectedly.
+  /// Waiting longer cannot help — an unbounded wait
+  /// hangs the caller's entire shutdown (see ChainSafe/lodestar#9744).
   pub shutdown_timeout: u32,
 
   /// Maximum duration of inactivity in ms to accept before timing out the connection.

--- a/rust/config.rs
+++ b/rust/config.rs
@@ -65,6 +65,9 @@ pub struct Config {
   /// The actual timeout is the minimum of this and the [`Config::max_idle_timeout`].
   pub handshake_timeout: u32,
 
+  /// Maximum duration in ms for draining the server endpoint during shutdown.
+  pub shutdown_timeout: u32,
+
   /// Maximum duration of inactivity in ms to accept before timing out the connection.
   pub max_idle_timeout: u32,
 
@@ -123,6 +126,7 @@ pub struct QuinnConfig {
   pub(crate) server_config: quinn::ServerConfig,
   pub(crate) endpoint_config: quinn::EndpointConfig,
   pub(crate) socket_config: SocketConfig,
+  pub(crate) shutdown_timeout: Duration,
 }
 
 #[napi]
@@ -138,6 +142,7 @@ impl TryFrom<Config> for QuinnConfig {
   fn try_from(config: Config) -> Result<QuinnConfig> {
     let Config {
       private_key_proto,
+      shutdown_timeout,
       max_idle_timeout,
       max_concurrent_stream_limit,
       keep_alive_interval,
@@ -210,6 +215,7 @@ impl TryFrom<Config> for QuinnConfig {
         receive_buffer_size,
         send_buffer_size,
       },
+      shutdown_timeout: Duration::from_millis(shutdown_timeout.into()),
     })
   }
 }

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -13,6 +13,15 @@ mod config;
 mod socket;
 mod stats;
 
+const SERVER_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+async fn completes_before_timeout<F>(future: F, duration: std::time::Duration) -> bool
+where
+  F: std::future::Future<Output = ()>,
+{
+  tokio::time::timeout(duration, future).await.is_ok()
+}
+
 #[napi]
 pub enum SocketFamily {
   Ipv4,
@@ -73,10 +82,19 @@ impl Server {
   }
 
   #[napi]
-  pub async fn abort(&self) {
+  pub async fn abort(&self) -> bool {
     self.endpoint.close(0u8.into(), b"");
-    self.endpoint.wait_idle().await;
-    self.socket.unbind().await;
+
+    // wait_idle() depends on every connection driver reaching the drained
+    // state. Bound the wait so one stalled driver cannot block listener close.
+    let drained =
+      completes_before_timeout(self.endpoint.wait_idle(), SERVER_SHUTDOWN_TIMEOUT).await;
+
+    // Always try to release the listening socket, including after a drain
+    // timeout. Acquiring the socket's write lock must also be bounded.
+    let unbound = completes_before_timeout(self.socket.unbind(), SERVER_SHUTDOWN_TIMEOUT).await;
+
+    drained && unbound
   }
 
   #[napi]

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -13,15 +13,6 @@ mod config;
 mod socket;
 mod stats;
 
-const SOCKET_UNBIND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
-
-async fn completes_before_timeout<F>(future: F, duration: std::time::Duration) -> bool
-where
-  F: std::future::Future<Output = ()>,
-{
-  tokio::time::timeout(duration, future).await.is_ok()
-}
-
 #[napi]
 pub enum SocketFamily {
   Ipv4,
@@ -83,18 +74,14 @@ impl Server {
   }
 
   #[napi]
-  pub async fn abort(&self) -> bool {
+  pub async fn abort(&self) {
     self.endpoint.close(0u8.into(), b"");
 
     // wait_idle() depends on every connection driver reaching the drained
-    // state. Bound the wait so one stalled driver cannot block listener close.
-    let drained = completes_before_timeout(self.endpoint.wait_idle(), self.shutdown_timeout).await;
+    // state, we bound the wait so one stalled driver cannot block listener close.
+    let _ = tokio::time::timeout(self.shutdown_timeout, self.endpoint.wait_idle()).await;
 
-    // Always try to release the listening socket, including after a drain
-    // timeout. Acquiring the socket's write lock must also be bounded.
-    let unbound = completes_before_timeout(self.socket.unbind(), SOCKET_UNBIND_TIMEOUT).await;
-
-    drained && unbound
+    self.socket.unbind().await;
   }
 
   #[napi]

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -13,7 +13,7 @@ mod config;
 mod socket;
 mod stats;
 
-const SERVER_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const SOCKET_UNBIND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
 async fn completes_before_timeout<F>(future: F, duration: std::time::Duration) -> bool
 where
@@ -32,6 +32,7 @@ pub enum SocketFamily {
 pub struct Server {
   socket: Arc<socket::UdpSocket>,
   endpoint: quinn::Endpoint,
+  shutdown_timeout: std::time::Duration,
 }
 
 #[napi]
@@ -63,7 +64,7 @@ impl Server {
         Arc::new(quinn::TokioRuntime),
       )
     })?;
-    Ok(Self { socket, endpoint })
+    Ok(Self { socket, endpoint, shutdown_timeout: config.shutdown_timeout })
   }
 
   #[napi]
@@ -87,12 +88,11 @@ impl Server {
 
     // wait_idle() depends on every connection driver reaching the drained
     // state. Bound the wait so one stalled driver cannot block listener close.
-    let drained =
-      completes_before_timeout(self.endpoint.wait_idle(), SERVER_SHUTDOWN_TIMEOUT).await;
+    let drained = completes_before_timeout(self.endpoint.wait_idle(), self.shutdown_timeout).await;
 
     // Always try to release the listening socket, including after a drain
     // timeout. Acquiring the socket's write lock must also be bounded.
-    let unbound = completes_before_timeout(self.socket.unbind(), SERVER_SHUTDOWN_TIMEOUT).await;
+    let unbound = completes_before_timeout(self.socket.unbind(), SOCKET_UNBIND_TIMEOUT).await;
 
     drained && unbound
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export function quic (options?: Partial<QuicOptions>): (components: QuicComponen
 
 export const defaultOptions: QuicOptions = {
   handshakeTimeout: 5_000,
+  shutdownTimeout: 3_000,
   maxIdleTimeout: 10_000,
   keepAliveInterval: 5_000,
   maxConcurrentStreamLimit: 256,

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,12 +57,26 @@ export interface QuicComponents {
 
 export type QuicDialOptions = DialTransportOptions
 
-export function quic (options?: Partial<QuicOptions>): (components: QuicComponents) => Transport {
+export function quic(options?: Partial<QuicOptions>): (components: QuicComponents) => Transport {
   return (components) => new QuicTransport(components, { ...defaultOptions, ...options })
 }
 
 export const defaultOptions: QuicOptions = {
   handshakeTimeout: 5_000,
+  /// The 3s default is derived from QUIC's draining period:
+  ///
+  /// quinn arms each connection's close/drain timer at 3x PTO (RFC 9000 §10.2)
+  ///
+  /// PTO = RTT + 4x RTT variance + the peer's max_ack_delay
+  ///
+  /// RTT = 333ms
+  /// RTT variance: RTT / 2
+  /// PTO = 333 ms + 4 × 166.5 ms = 999 ms
+  /// 3 * PTO = roughly 3s
+  ///
+  /// This timeout can only trip when a connection driver has stopped unexpectedly.
+  /// Waiting longer cannot help — an unbounded wait
+  /// hangs the caller's entire shutdown (see ChainSafe/lodestar#9744).
   shutdownTimeout: 3_000,
   maxIdleTimeout: 10_000,
   keepAliveInterval: 5_000,

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -147,7 +147,11 @@ export class QuicListener extends TypedEventEmitter<ListenerEvents> implements L
         conn.abort(new Error('listener closed'))
       }
       this.state.connections.clear()
-      await this.state.listener.abort()
+      const cleanShutdown = await this.state.listener.abort()
+      if (!cleanShutdown) {
+        this.log.error('timed out waiting for QUIC listener shutdown')
+        this.metrics.errors?.increment({ [`${this.addr} close_timeout`]: true })
+      }
       const listenAddr = this.state.listenAddr
       this.state = { status: 'closed' }
       // stop any in-progress connection upgrades

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -147,11 +147,7 @@ export class QuicListener extends TypedEventEmitter<ListenerEvents> implements L
         conn.abort(new Error('listener closed'))
       }
       this.state.connections.clear()
-      const cleanShutdown = await this.state.listener.abort()
-      if (!cleanShutdown) {
-        this.log.error('timed out waiting for QUIC listener shutdown')
-        this.metrics.errors?.increment({ [`${this.addr} close_timeout`]: true })
-      }
+      await this.state.listener.abort()
       const listenAddr = this.state.listenAddr
       this.state = { status: 'closed' }
       // stop any in-progress connection upgrades

--- a/src/napi.d.ts
+++ b/src/napi.d.ts
@@ -343,7 +343,7 @@ export declare class Server {
   constructor(config: QuinnConfig, ip: string, port: number)
   port(): number
   inboundConnection(): Promise<Connection>
-  abort(): Promise<void>
+  abort(): Promise<boolean>
   stats(): EndpointStats
 }
 

--- a/src/napi.d.ts
+++ b/src/napi.d.ts
@@ -365,7 +365,24 @@ export interface Config {
    * The actual timeout is the minimum of this and the [`Config::max_idle_timeout`].
    */
   handshakeTimeout: number
-  /** Maximum duration in ms for draining the server endpoint during shutdown. */
+  /**
+   * Maximum duration in ms for draining the server endpoint during shutdown.
+   *
+   * The 3s default is derived from QUIC's draining period: 
+   *
+   * quinn arms each connection's close/drain timer at 3x PTO (RFC 9000 §10.2)
+   *
+   * PTO = RTT + 4x RTT variance + the peer's max_ack_delay
+   *
+   * RTT = 333ms
+   * RTT variance: RTT / 2
+   * PTO = 333 ms + 4 × 166.5 ms = 999 ms
+   * 3 * PTO = roughly 3s
+   *
+   * This timeout can only trip when a connection driver has stopped unexpectedly. 
+   * Waiting longer cannot help — an unbounded wait
+   * hangs the caller's entire shutdown (see ChainSafe/lodestar#9744).
+   */
   shutdownTimeout: number
   /** Maximum duration of inactivity in ms to accept before timing out the connection. */
   maxIdleTimeout: number

--- a/src/napi.d.ts
+++ b/src/napi.d.ts
@@ -367,21 +367,6 @@ export interface Config {
   handshakeTimeout: number
   /**
    * Maximum duration in ms for draining the server endpoint during shutdown.
-   *
-   * The 3s default is derived from QUIC's draining period: 
-   *
-   * quinn arms each connection's close/drain timer at 3x PTO (RFC 9000 §10.2)
-   *
-   * PTO = RTT + 4x RTT variance + the peer's max_ack_delay
-   *
-   * RTT = 333ms
-   * RTT variance: RTT / 2
-   * PTO = 333 ms + 4 × 166.5 ms = 999 ms
-   * 3 * PTO = roughly 3s
-   *
-   * This timeout can only trip when a connection driver has stopped unexpectedly. 
-   * Waiting longer cannot help — an unbounded wait
-   * hangs the caller's entire shutdown (see ChainSafe/lodestar#9744).
    */
   shutdownTimeout: number
   /** Maximum duration of inactivity in ms to accept before timing out the connection. */

--- a/src/napi.d.ts
+++ b/src/napi.d.ts
@@ -343,7 +343,7 @@ export declare class Server {
   constructor(config: QuinnConfig, ip: string, port: number)
   port(): number
   inboundConnection(): Promise<Connection>
-  abort(): Promise<boolean>
+  abort(): Promise<void>
   stats(): EndpointStats
 }
 

--- a/src/napi.d.ts
+++ b/src/napi.d.ts
@@ -365,6 +365,8 @@ export interface Config {
    * The actual timeout is the minimum of this and the [`Config::max_idle_timeout`].
    */
   handshakeTimeout: number
+  /** Maximum duration in ms for draining the server endpoint during shutdown. */
+  shutdownTimeout: number
   /** Maximum duration of inactivity in ms to accept before timing out the connection. */
   maxIdleTimeout: number
   /**


### PR DESCRIPTION
It is likely that quinn's `wait_idle` is causing the lodestar process to wait indefinitely like in https://github.com/ChainSafe/lodestar/issues/9744. `wait_idle` returns only after every connection has been removed from the endpoint connection map. A connection is normally removed when its `ConnectionDriver` emits a `Drained` event.

A driver can stall for whatever reason and not emit this event. This lib retains these references through native `Connection` objects and pending `connection.closed()` promises, so the entry can remain indefinitely.

The fix is we just wait for 3s before timing out on waiting for `wait_idle` to finish.

 [RFC 9000 Section 10.2](https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2) explicitly permits ending the closing or draining state early when the endpoint can close its UDP socket:

> Endpoints that have some alternative means to ensure that late-arriving packets do not induce a response,
> such as those that are able to close the UDP socket, MAY end these states earlier.

**Why 3s?** 

Quinn calculates PTO as:

 ```rust
   PTO = RTT estimate + max(4 × RTT variance, timer granularity) + max ACK delay
 ```

 Sources:

 - [Connection::pto()](https://github.com/quinn-rs/quinn/blob/b2b930a0662b18b2e351264a21e175478bb3c3f1/quinn-proto/src/connection/mod.rs#L1894-L1901)
 - [RttEstimator::pto_base()](https://github.com/quinn-rs/quinn/blob/b2b930a0662b18b2e351264a21e175478bb3c3f1/quinn-proto/src/connection/paths.rs#L324-L327)
 - [RFC 9002 §6.2.1](https://www.rfc-editor.org/rfc/rfc9002.html#section-6.2.1)
 - [RFC 9000 §10.2](https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2) recommends retaining closing and draining state for at least three PTO periods.

 Quinn’s initial estimate

 Quinn starts with:

 ```rust
   initial_rtt: Duration::from_millis(333)
   rtt_variance: initial_rtt / 2
 ```

 Source: [TransportConfig](https://github.com/quinn-rs/quinn/blob/b2b930a0662b18b2e351264a21e175478bb3c3f1/quinn-proto/src/config/transport.rs#L368-L374)[ default](https://github.com/quinn-rs/quinn/blob/b2b930a0662b18b2e351264a21e175478bb3c3f1/quinn-proto/src/config/transport.rs#L368-L374)

 Therefore:

 ```text
   PTO = 333 ms + 4 × 166.5 ms
       = 999 ms

   Drain = 3 × 999 ms
         = 2.997 seconds
 ```

 For established application-data connections, the usual 25 ms ACK delay makes that approximately 3.07 seconds.
